### PR TITLE
Add FastAPI prototype for family tree service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
+Open http://localhost:8000/ in a browser to use a minimal web interface for signing up, creating a tree, and adding persons.
+
 ## Running tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # MainGen
+
+A simplified prototype of a family tree service. It provides minimal API endpoints for user authentication, tree management, person records, and relationships using FastAPI. This is an in-memory prototype derived from the MVP requirements.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the app
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Running tests
+
+```bash
+pytest
+```

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,40 @@
+from typing import Dict
+from uuid import uuid4
+
+from passlib.context import CryptContext
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class UserStore:
+    def __init__(self):
+        self._users: Dict[str, str] = {}
+
+    def create_user(self, email: str, password: str):
+        if email in self._users:
+            raise ValueError("user exists")
+        self._users[email] = pwd_context.hash(password)
+
+    def verify_user(self, email: str, password: str) -> bool:
+        hashed = self._users.get(email)
+        if not hashed:
+            return False
+        return pwd_context.verify(password, hashed)
+
+
+class TokenStore:
+    def __init__(self):
+        self._tokens: Dict[str, str] = {}
+
+    def issue(self, email: str) -> str:
+        token = uuid4().hex
+        self._tokens[token] = email
+        return token
+
+    def get_email(self, token: str) -> str | None:
+        return self._tokens.get(token)
+
+
+user_store = UserStore()
+token_store = TokenStore()

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,7 @@
 from fastapi import Depends, FastAPI, Header, HTTPException, status
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+import pathlib
 
 from .auth import token_store, user_store
 from .schemas import (
@@ -14,6 +17,14 @@ from .schemas import (
 )
 
 app = FastAPI(title="MainGen")
+
+static_dir = pathlib.Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.get("/", response_class=FileResponse)
+def read_index():
+    return FileResponse(static_dir / "index.html")
 
 # In-memory stores
 class TreeStore:

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,127 @@
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+
+from .auth import token_store, user_store
+from .schemas import (
+    PersonCreate,
+    PersonResponse,
+    RelationshipCreate,
+    RelationshipResponse,
+    SigninRequest,
+    SignupRequest,
+    TokenResponse,
+    TreeCreate,
+    TreeResponse,
+)
+
+app = FastAPI(title="MainGen")
+
+# In-memory stores
+class TreeStore:
+    def __init__(self):
+        self._trees = {}
+        self._persons = {}
+        self._relationships = {}
+        self._tree_counter = 1
+        self._person_counter = 1
+        self._relationship_counter = 1
+
+    def create_tree(self, owner_email: str, data: TreeCreate) -> TreeResponse:
+        tree_id = self._tree_counter
+        self._tree_counter += 1
+        self._trees[tree_id] = {"id": tree_id, "name": data.name, "owner": owner_email}
+        self._persons[tree_id] = {}
+        self._relationships[tree_id] = {}
+        return TreeResponse(id=tree_id, **data.model_dump())
+
+    def get_tree(self, tree_id: int) -> TreeResponse | None:
+        t = self._trees.get(tree_id)
+        if not t:
+            return None
+        return TreeResponse(**t)
+
+    def add_person(self, tree_id: int, person: PersonCreate) -> PersonResponse:
+        if tree_id not in self._trees:
+            raise ValueError("tree not found")
+        pid = self._person_counter
+        self._person_counter += 1
+        data = person.model_dump()
+        data.update({"id": pid, "tree_id": tree_id})
+        self._persons[tree_id][pid] = data
+        return PersonResponse(**data)
+
+    def list_persons(self, tree_id: int):
+        return [PersonResponse(**p) for p in self._persons.get(tree_id, {}).values()]
+
+    def add_relationship(self, tree_id: int, rel: RelationshipCreate) -> RelationshipResponse:
+        if tree_id not in self._trees:
+            raise ValueError("tree not found")
+        rid = self._relationship_counter
+        self._relationship_counter += 1
+        data = rel.model_dump()
+        data.update({"id": rid, "tree_id": tree_id})
+        self._relationships[tree_id][rid] = data
+        return RelationshipResponse(**data)
+
+
+store = TreeStore()
+
+
+def get_current_email(token: str | None = Header(default=None)) -> str:
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing token")
+    email = token_store.get_email(token)
+    if not email:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+    return email
+
+
+@app.post("/auth/signup", response_model=TokenResponse)
+def signup(payload: SignupRequest):
+    try:
+        user_store.create_user(payload.email, payload.password)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="user exists")
+    token = token_store.issue(payload.email)
+    return TokenResponse(access_token=token)
+
+
+@app.post("/auth/signin", response_model=TokenResponse)
+def signin(payload: SigninRequest):
+    if not user_store.verify_user(payload.email, payload.password):
+        raise HTTPException(status_code=400, detail="invalid credentials")
+    token = token_store.issue(payload.email)
+    return TokenResponse(access_token=token)
+
+
+@app.post("/trees", response_model=TreeResponse)
+def create_tree(data: TreeCreate, email: str = Depends(get_current_email)):
+    return store.create_tree(email, data)
+
+
+@app.get("/trees/{tree_id}", response_model=TreeResponse)
+def get_tree(tree_id: int, email: str = Depends(get_current_email)):
+    tree = store.get_tree(tree_id)
+    if not tree:
+        raise HTTPException(status_code=404, detail="tree not found")
+    return tree
+
+
+@app.post("/trees/{tree_id}/persons", response_model=PersonResponse)
+def add_person(tree_id: int, person: PersonCreate, email: str = Depends(get_current_email)):
+    try:
+        return store.add_person(tree_id, person)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="tree not found")
+
+
+@app.get("/trees/{tree_id}/persons", response_model=list[PersonResponse])
+def list_persons(tree_id: int, email: str = Depends(get_current_email)):
+    return store.list_persons(tree_id)
+
+
+@app.post("/trees/{tree_id}/relationships", response_model=RelationshipResponse)
+def add_relationship(tree_id: int, rel: RelationshipCreate, email: str = Depends(get_current_email)):
+    try:
+        return store.add_relationship(tree_id, rel)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="tree not found")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,61 @@
+from datetime import date
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=6)
+
+
+class SigninRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+
+
+class TreeCreate(BaseModel):
+    name: str
+
+
+class TreeResponse(TreeCreate):
+    id: int
+
+
+class Gender(str, Enum):
+    male = "male"
+    female = "female"
+    unknown = "unknown"
+
+
+class PersonCreate(BaseModel):
+    first_name: str
+    last_name: str
+    gender: Gender = Gender.unknown
+    birth_date: Optional[date] = None
+
+
+class PersonResponse(PersonCreate):
+    id: int
+    tree_id: int
+
+
+class RelationshipType(str, Enum):
+    parent = "parent"
+    spouse = "spouse"
+
+
+class RelationshipCreate(BaseModel):
+    person_a_id: int
+    person_b_id: int
+    type: RelationshipType
+
+
+class RelationshipResponse(RelationshipCreate):
+    id: int
+    tree_id: int

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,73 @@
+let token = "";
+let treeId = null;
+
+async function post(url, data) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { token } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text);
+  }
+  return res.json();
+}
+
+document.getElementById("signup-form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const email = document.getElementById("signup-email").value;
+  const password = document.getElementById("signup-password").value;
+  const data = await post("/auth/signup", { email, password });
+  token = data.access_token;
+  document.getElementById("token").textContent = token;
+});
+
+document.getElementById("signin-form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const email = document.getElementById("signin-email").value;
+  const password = document.getElementById("signin-password").value;
+  const data = await post("/auth/signin", { email, password });
+  token = data.access_token;
+  document.getElementById("token").textContent = token;
+});
+
+document.getElementById("tree-form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const name = document.getElementById("tree-name").value;
+  const data = await post("/trees", { name });
+  treeId = data.id;
+  document.getElementById("tree-id").textContent = treeId;
+  await listPeople();
+});
+
+document.getElementById("person-form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  if (!treeId) {
+    alert("Create a tree first");
+    return;
+  }
+  const first_name = document.getElementById("person-first").value;
+  const last_name = document.getElementById("person-last").value;
+  await post(`/trees/${treeId}/persons`, { first_name, last_name, gender: "unknown" });
+  await listPeople();
+});
+
+async function listPeople() {
+  if (!treeId) return;
+  const res = await fetch(`/trees/${treeId}/persons`, {
+    headers: token ? { token } : {},
+  });
+  if (!res.ok) return;
+  const data = await res.json();
+  const list = document.getElementById("people-list");
+  list.innerHTML = "";
+  data.forEach((p) => {
+    const li = document.createElement("li");
+    li.textContent = `${p.id}: ${p.first_name} ${p.last_name}`;
+    list.appendChild(li);
+  });
+}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>MainGen Prototype</title>
+</head>
+<body>
+  <h1>MainGen Prototype</h1>
+
+  <section>
+    <h2>Signup</h2>
+    <form id="signup-form">
+      <input type="email" id="signup-email" placeholder="Email" required />
+      <input type="password" id="signup-password" placeholder="Password" required />
+      <button type="submit">Sign up</button>
+    </form>
+  </section>
+
+  <section>
+    <h2>Signin</h2>
+    <form id="signin-form">
+      <input type="email" id="signin-email" placeholder="Email" required />
+      <input type="password" id="signin-password" placeholder="Password" required />
+      <button type="submit">Sign in</button>
+    </form>
+    <p>Token: <span id="token"></span></p>
+  </section>
+
+  <section>
+    <h2>Create Tree</h2>
+    <form id="tree-form">
+      <input type="text" id="tree-name" placeholder="Tree Name" required />
+      <button type="submit">Create</button>
+    </form>
+    <p>Tree ID: <span id="tree-id"></span></p>
+  </section>
+
+  <section>
+    <h2>Add Person</h2>
+    <form id="person-form">
+      <input type="text" id="person-first" placeholder="First Name" required />
+      <input type="text" id="person-last" placeholder="Last Name" required />
+      <button type="submit">Add Person</button>
+    </form>
+    <ul id="people-list"></ul>
+  </section>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+passlib[bcrypt]==1.7.4
+pytest==8.0.0
+httpx==0.26.0
+email-validator==2.1.0.post1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -34,3 +34,9 @@ def test_create_tree_and_person():
     list_res = client.get(f"/trees/{tree_id}/persons", headers=headers)
     assert list_res.status_code == 200
     assert len(list_res.json()) == 1
+
+
+def test_index_served():
+    res = client.get("/")
+    assert res.status_code == 200
+    assert "MainGen Prototype" in res.text

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def auth_headers():
+    res = client.post("/auth/signup", json={"email": "user@example.com", "password": "secret123"})
+    token = res.json()["access_token"]
+    return {"token": token}
+
+
+def test_create_tree_and_person():
+    headers = auth_headers()
+    tree_res = client.post("/trees", json={"name": "Family"}, headers=headers)
+    assert tree_res.status_code == 200
+    tree_id = tree_res.json()["id"]
+
+    person_res = client.post(
+        f"/trees/{tree_id}/persons",
+        json={"first_name": "Ivan", "last_name": "Ivanov", "gender": "male"},
+        headers=headers,
+    )
+    assert person_res.status_code == 200
+    data = person_res.json()
+    assert data["first_name"] == "Ivan"
+
+    list_res = client.get(f"/trees/{tree_id}/persons", headers=headers)
+    assert list_res.status_code == 200
+    assert len(list_res.json()) == 1


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with in-memory stores for trees, persons, and relationships
- add basic signup/signin flows using simple token auth
- include pytest verifying tree and person creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f970297f0832085fb1d946c5e2e97